### PR TITLE
SERVER_PORT env variable fix

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     image: nginx:latest
     depends_on:
       - webapi
-      - webapp
+      - 3cxcdrtcpserver_ui
     restart: unless-stopped
     env_file:
       - .env
@@ -171,12 +171,6 @@ volumes:
       device: .
       o: bind
   ui-dir:
-    driver: local
-    driver_opts:
-      type: none
-      device: .
-      o: bind
-  webapp-dir:
     driver: local
     driver_opts:
       type: none

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     image: nginx:latest
     depends_on:
       - webapi
-      - 3cxcdrtcpserver_ui
+      - webapp
     restart: unless-stopped
     env_file:
       - .env
@@ -171,6 +171,12 @@ volumes:
       device: .
       o: bind
   ui-dir:
+    driver: local
+    driver_opts:
+      type: none
+      device: .
+      o: bind
+  webapp-dir:
     driver: local
     driver_opts:
       type: none

--- a/myhelpers/config.py
+++ b/myhelpers/config.py
@@ -16,6 +16,7 @@ def get_client_config(server_type):
         'SCP_3CX_PASSWORD': os.environ.get('SCP_3CX_PASSWORD'),
         'SCP_3CX_PORT': int(os.environ.get('SCP_3CX_PORT', '22')),
         'SCP_3CX_SRVDIR': os.environ.get('SCP_3CX_SRVDIR'),
+        'SERVER_PORT': int(os.environ.get('SERVER_PORT', 5000')),
     }
 
     if server_type == 'FTP':

--- a/myhelpers/config.py
+++ b/myhelpers/config.py
@@ -16,7 +16,7 @@ def get_client_config(server_type):
         'SCP_3CX_PASSWORD': os.environ.get('SCP_3CX_PASSWORD'),
         'SCP_3CX_PORT': int(os.environ.get('SCP_3CX_PORT', '22')),
         'SCP_3CX_SRVDIR': os.environ.get('SCP_3CX_SRVDIR'),
-        'SERVER_PORT': int(os.environ.get('SERVER_PORT', 5000')),
+        'SERVER_PORT': int(os.environ.get('SERVER_PORT', '5000')),
     }
 
     if server_type == 'FTP':


### PR DESCRIPTION
Add `SERVER_PORT` to config.py.

While 3CX's default port is 3000, this is already used by Grafana, so opted for 5000.