### PR TITLE
Fix code scanning alert no. 6: Clear-text logging of sensitive information

### DIFF
--- a/myhelpers/scpclient.py
+++ b/myhelpers/scpclient.py
@@ -55,7 +55,7 @@ class scpclient():
                                        
                     scp.get(remote_path=scpfilename,
                             local_path=os.path.join(localfolder, f))
-                    logger.info("file downloaded:" + scpfilename)
+                    logger.info("File downloaded successfully.")
                     if os.environ.get('3CX_FILES_ARCHIVE_OR_DELETE') == 'ARCHIVE':
                         #ssh.exec_command(f"sudo mv {scpfilename} .old")
                         sftp.rename(scpfilename,f"{scpfilename}.old")


### PR DESCRIPTION
Fixes [https://github.com/dorel14/3CX-Cdr-Server/security/code-scanning/6](https://github.com/dorel14/3CX-Cdr-Server/security/code-scanning/6)

To fix the problem, we should avoid logging the full `scpfilename` directly. Instead, we can log a more generic message that does not include potentially sensitive information. For example, we can log a message indicating that a file has been downloaded without specifying the exact file name or path.

- Replace the log message on line 58 with a more generic message.
- Ensure that the new log message does not include any sensitive information.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
